### PR TITLE
Ch4 permutation

### DIFF
--- a/docs/chapter04.md
+++ b/docs/chapter04.md
@@ -78,4 +78,4 @@ $$
 \end{bmatrix}
 $$
 
-$n$阶方阵的置换矩阵有$\binom{n}{1}=n!$个。
+$n$阶方阵的置换矩阵有$\newcommand\Myperm[2][^n]{{#1\mkern-2.5mu}{}P_{#2}}\Myperm{n}=n!$个。

--- a/docs/chapter04.md
+++ b/docs/chapter04.md
@@ -78,4 +78,4 @@ $$
 \end{bmatrix}
 $$
 
-$n$阶方阵的置换矩阵有$\newcommand\Myperm[2][^n]{{#1\mkern-2.5mu}{}P_{#2}}\Myperm{n}=n!$个。
+$n$阶方阵的置换矩阵有$P(n,n)=n!$个。


### PR DESCRIPTION
承https://github.com/apachecn/mit-18.06-linalg-notes/pull/55, KaTex不支持\newcommand语法，故用$P(n,n)$取代。